### PR TITLE
Twinkle / Flashlight effect on attracted nodes

### DIFF
--- a/OriginNode.pde
+++ b/OriginNode.pde
@@ -10,6 +10,8 @@ public class OriginNode extends Node {
   final int baseOpacity = 128;
   int toOpacity = 128;
   int opacity = 128;
+  boolean inField = false;
+  boolean triggered = false;
   
   // ------ constructors ------
   
@@ -78,16 +80,17 @@ public class OriginNode extends Node {
     // since we are updating the toOpacity on every frame most likely, 
     // we know that whenver the opacity is above the base, the toOpacity
     // needs to stay bottomed out regardless of who is updating the value.
-    if (this.opacity > this.baseOpacity) {
+    if (this.opacity > this.baseOpacity || this.triggered) {
       this.toOpacity = this.baseOpacity;
     }
     
     if (this.toOpacity > this.opacity) {
       // shoot the value all the way up.
       this.opacity = this.toOpacity;
+      this.triggered = true;
     } else if (this.opacity > this.toOpacity) {
       // slowly transition back down.
-      this.opacity -= 15;
+      this.opacity -= 25;
     } else {
       // if we've gone too far, return back to the base.
       this.opacity = this.baseOpacity;
@@ -97,6 +100,8 @@ public class OriginNode extends Node {
   void resetOpacity() {
     this.toOpacity = this.baseOpacity;
     this.opacity   = this.baseOpacity;
+    this.inField   = false; // todo: field not needed.
+    this.triggered = false;
   }
   
 }

--- a/OriginNode.pde
+++ b/OriginNode.pde
@@ -10,7 +10,6 @@ public class OriginNode extends Node {
   final int baseOpacity = 128;
   int toOpacity = 128;
   int opacity = 128;
-  boolean inField = false;
   boolean triggered = false;
   
   // ------ constructors ------
@@ -100,7 +99,6 @@ public class OriginNode extends Node {
   void resetOpacity() {
     this.toOpacity = this.baseOpacity;
     this.opacity   = this.baseOpacity;
-    this.inField   = false; // todo: field not needed.
     this.triggered = false;
   }
   

--- a/OriginNode.pde
+++ b/OriginNode.pde
@@ -7,6 +7,8 @@ public class OriginNode extends Node {
   boolean isReturning;
   PVector returnVelocity = new PVector();
   
+  int opacity = 128;
+  
   // ------ constructors ------
   
   public OriginNode() {

--- a/OriginNode.pde
+++ b/OriginNode.pde
@@ -7,6 +7,8 @@ public class OriginNode extends Node {
   boolean isReturning;
   PVector returnVelocity = new PVector();
   
+  final int baseOpacity = 128;
+  int toOpacity = 128;
   int opacity = 128;
   
   // ------ constructors ------
@@ -45,6 +47,8 @@ public class OriginNode extends Node {
   // functions
   
   public void update() {
+    updateOpacity();
+    
     boolean velocityStopped = (velocity.x <= 0.09 && velocity.x >= -0.09) 
       && (velocity.y <= 0.09 && velocity.y >= -0.09);
     
@@ -69,4 +73,30 @@ public class OriginNode extends Node {
       }
     }
   }
+  
+  void updateOpacity() {
+    // since we are updating the toOpacity on every frame most likely, 
+    // we know that whenver the opacity is above the base, the toOpacity
+    // needs to stay bottomed out regardless of who is updating the value.
+    if (this.opacity > this.baseOpacity) {
+      this.toOpacity = this.baseOpacity;
+    }
+    
+    if (this.toOpacity > this.opacity) {
+      // shoot the value all the way up.
+      this.opacity = this.toOpacity;
+    } else if (this.opacity > this.toOpacity) {
+      // slowly transition back down.
+      this.opacity -= 15;
+    } else {
+      // if we've gone too far, return back to the base.
+      this.opacity = this.baseOpacity;
+    }
+  }
+  
+  void resetOpacity() {
+    this.toOpacity = this.baseOpacity;
+    this.opacity   = this.baseOpacity;
+  }
+  
 }

--- a/User.pde
+++ b/User.pde
@@ -22,6 +22,10 @@ class User {
   Attractor rightAttractor;
   Attractor chestAttractor;
   
+  boolean leftMoved  = false;
+  boolean rightMoved = false;
+  boolean chestMoved = false;
+  
   int xCount;
   int yCount;
   
@@ -41,9 +45,9 @@ class User {
                         Math.round(random(100, 255)), 
                         128);
     this.cChestName = getClosestNameFromColor(this.cChest);
-    this.chestPosn = chestPosn;
-    this.lHandPosn = lHandPosn;
-    this.rHandPosn = rHandPosn;
+    this.chestPosn  = chestPosn;
+    this.lHandPosn  = lHandPosn;
+    this.rHandPosn  = rHandPosn;
     
     // grid size is a vector where x -> width, y -> height
     this.gridSize = new PVector(Math.round(random(1400, displayWidth)), 
@@ -161,18 +165,24 @@ class User {
       
       // todo: the toOpacity should be refactored somehow...
       
-      if (leftAttractor.dist(currentNode) < leftAttractor.radius) {
+      if (leftAttractor.dist(currentNode) < leftAttractor.radius / 2) {
         currentlyGatheredNodes += 1;
+        if (leftMoved) {
+          currentNode.resetOpacity();
+        }
         currentNode.toOpacity = 255;
-        currentNode.inField = true;
-      } else if (rightAttractor.dist(currentNode) < rightAttractor.radius) {
+      } else if (rightAttractor.dist(currentNode) < rightAttractor.radius / 2) {
         currentlyGatheredNodes += 1;
+        if (rightMoved) {
+          currentNode.resetOpacity();
+        }
         currentNode.toOpacity = 255;
-        currentNode.inField = true;
-      } else if (chestAttractor.dist(currentNode) < chestAttractor.radius) {
+      } else if (chestAttractor.dist(currentNode) < chestAttractor.radius / 2) {
         currentlyGatheredNodes += 1;
+        if (chestMoved) {
+          currentNode.resetOpacity();
+        }
         currentNode.toOpacity = 255;
-        currentNode.inField = true;
       } else {
         currentNode.resetOpacity();
       }
@@ -187,6 +197,12 @@ class User {
   }
   
   void updateAttractors(KJoint lHand, KJoint rHand) {
+    
+    // determine if attractors moved
+    
+    leftMoved  = euclideanDistance(this.lHandPosn, new PVector(leftAttractor.x, leftAttractor.y)) > 5;
+    rightMoved = euclideanDistance(this.rHandPosn, new PVector(rightAttractor.x, rightAttractor.y)) > 5;
+    chestMoved = euclideanDistance(this.chestPosn, new PVector(chestAttractor.x, chestAttractor.y)) > 5;
     
     // update positions
     

--- a/User.pde
+++ b/User.pde
@@ -154,21 +154,24 @@ class User {
     
     for (int j = 0; j < this.nodes.length; j++) {
       OriginNode currentNode = this.nodes[j];
-      currentNode.opacity = 128;
       
       leftAttractor.attract(currentNode);
       rightAttractor.attract(currentNode);
       chestAttractor.attract(currentNode);
       
+      // todo: the toOpacity should be refactored somehow...
+      
       if (leftAttractor.dist(currentNode) < leftAttractor.radius) {
         currentlyGatheredNodes += 1;
-        currentNode.opacity = 255;
+        currentNode.toOpacity = 255;
       } else if (rightAttractor.dist(currentNode) < rightAttractor.radius) {
         currentlyGatheredNodes += 1;
-        currentNode.opacity = 255;  
+        currentNode.toOpacity = 255;  
       } else if (chestAttractor.dist(currentNode) < chestAttractor.radius) {
         currentlyGatheredNodes += 1;
-        currentNode.opacity = 255;
+        currentNode.toOpacity = 255;
+      } else {
+        currentNode.resetOpacity();
       }
   
       this.nodes[j].update();
@@ -214,9 +217,9 @@ class User {
       }
   }
   
-  // -------------
-  // ??? Functions
-  // -------------
+  // --------------
+  // Draw Functions
+  // --------------
   
   void draw() {
     

--- a/User.pde
+++ b/User.pde
@@ -38,7 +38,8 @@ class User {
        PVector rHandPosn) {
     this.cChest = color(Math.round(random(100, 255)), 
                         Math.round(random(100, 255)), 
-                        Math.round(random(100, 255)), 100);
+                        Math.round(random(100, 255)), 
+                        128);
     this.cChestName = getClosestNameFromColor(this.cChest);
     this.chestPosn = chestPosn;
     this.lHandPosn = lHandPosn;
@@ -153,6 +154,7 @@ class User {
     
     for (int j = 0; j < this.nodes.length; j++) {
       OriginNode currentNode = this.nodes[j];
+      currentNode.opacity = 128;
       
       leftAttractor.attract(currentNode);
       rightAttractor.attract(currentNode);
@@ -160,10 +162,13 @@ class User {
       
       if (leftAttractor.dist(currentNode) < leftAttractor.radius) {
         currentlyGatheredNodes += 1;
+        currentNode.opacity = 255;
       } else if (rightAttractor.dist(currentNode) < rightAttractor.radius) {
         currentlyGatheredNodes += 1;
+        currentNode.opacity = 255;  
       } else if (chestAttractor.dist(currentNode) < chestAttractor.radius) {
         currentlyGatheredNodes += 1;
+        currentNode.opacity = 255;
       }
   
       this.nodes[j].update();
@@ -216,12 +221,18 @@ class User {
   void draw() {
     
     // draw each node
-    
-    for (int j = 0; j < this.nodes.length; j++) {
-      fill(this.cChest);
-      rect(this.nodes[j].x, this.nodes[j].y, nodeSize, nodeSize);
+    for (OriginNode currentNode : this.nodes) {
+      fill(red(this.cChest), green(this.cChest), blue(this.cChest), currentNode.opacity);
+      rect(currentNode.x, currentNode.y, nodeSize, nodeSize);
     }
     
+    drawDebug();
+  }
+  
+  /*
+   * @description draws text related to debugging the program. 
+   */
+  void drawDebug() {
     fill(255,0,0);
     text(Math.round(this.getAverageNodeVelocity() * 1000), 50, 70);
     

--- a/User.pde
+++ b/User.pde
@@ -164,12 +164,15 @@ class User {
       if (leftAttractor.dist(currentNode) < leftAttractor.radius) {
         currentlyGatheredNodes += 1;
         currentNode.toOpacity = 255;
+        currentNode.inField = true;
       } else if (rightAttractor.dist(currentNode) < rightAttractor.radius) {
         currentlyGatheredNodes += 1;
-        currentNode.toOpacity = 255;  
+        currentNode.toOpacity = 255;
+        currentNode.inField = true;
       } else if (chestAttractor.dist(currentNode) < chestAttractor.radius) {
         currentlyGatheredNodes += 1;
         currentNode.toOpacity = 255;
+        currentNode.inField = true;
       } else {
         currentNode.resetOpacity();
       }


### PR DESCRIPTION
For any node that's within half the radius of the gravitational field of an attractor, max out the opacity and transition back down. This is so we can signify to users where their joints are in the visual space.